### PR TITLE
Stabilize tests & dependency stack (v0.1.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install -r requirements.txt flake8 pytest
+      - run: pip install -r requirements-dev.txt
       - run: flake8
       - run: pytest
       - run: docker compose build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        args: ["-l", "88"]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["-l", "88"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,14 @@
 # Contributing Guide
 
 Thank you for considering contributing. Please open an issue to propose changes before submitting PRs.
+
+## Development workflow
+
+Install the development requirements and set up pre-commit hooks:
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+Run `pre-commit run --all-files` before pushing to ensure formatting and lint checks pass.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenReliefKit
 
+![CI](https://github.com/OpenRelief/OpenReliefKit/actions/workflows/ci.yml/badge.svg)
+
 OpenReliefKit provides a ready-to-extend toolkit for rapid disaster response. Our goal is to lower the barrier for communities and NGOs to deploy essential tools in the first hours after a disaster. Clone the repo and spin up a communication hub, crisis map, and resource tracker in minutes.
 
 ## Quick start

--- a/core/crisis_map/Dockerfile
+++ b/core/crisis_map/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY ../../requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+COPY ../../requirements.txt ../../requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir -r requirements-dev.txt
 COPY backend ./backend
 COPY frontend ./frontend
 CMD ["uvicorn", "backend.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/core/crisis_map/backend/app.py
+++ b/core/crisis_map/backend/app.py
@@ -1,13 +1,17 @@
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 
-
 app = FastAPI()
 
 
 @app.get("/")
 def read_root():
     return {"message": "Crisis Map API"}
+
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}
 
 
 @app.get("/ui", response_class=HTMLResponse)

--- a/core/resource_tracker/app.py
+++ b/core/resource_tracker/app.py
@@ -1,9 +1,13 @@
 from fastapi import FastAPI
 
-
 app = FastAPI()
 
 
 @app.get("/")
 def read_root():
     return {"message": "Resource Tracker"}
+
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest==8.3.*
+httpx==0.27.*
+flake8==7.0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-fastapi
-uvicorn
-pytest
-httpx
+fastapi==0.111.*
+starlette==0.37.*
+uvicorn[standard]==0.30.*

--- a/tests/test_crisis_map.py
+++ b/tests/test_crisis_map.py
@@ -1,8 +1,4 @@
 from fastapi.testclient import TestClient
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.crisis_map.backend.app import app
 
@@ -13,3 +9,9 @@ def test_root():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Crisis Map API"}
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -1,8 +1,4 @@
 from fastapi.testclient import TestClient
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.resource_tracker.app import app
 
@@ -13,3 +9,9 @@ def test_root():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Resource Tracker"}
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- pin FastAPI and Starlette versions
- add development requirements file
- install dev requirements in Docker and CI
- add `/health` endpoints and tests
- set up pre-commit hooks
- document contributing workflow
- show CI badge in README

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417bad34808322b6fcffe0c5539673